### PR TITLE
Allow configuration to be added with addurl calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,16 @@ However, because the SABnzbd API is horribly inconsistent at times, I've added s
 
 * Delete an NZB from the queue. See `instance.delete()` for arguments.
 
-#### `instance.queue.addurl(URL)`
+#### `instance.queue.addurl(URL | ARGS)`
 
-* Add an NZB to the queue by URL.
+* Add an NZB to the queue by URL. Or an ARGS object.
     
     _Arguments_:
     
     * `URL`
         - url pointing to an NZB file
+    * `ARGS` [Sab API Docs](http://wiki.sabnzbd.org/api#toc28)
+        - Object containing at least `name`=URL and any of the following options `pp`=Post Process Level, `script`=Post Process Script, `cat`=Category, `priority`=Priority
 
 #### `instance.queue.pause([ID])`
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ However, because the SABnzbd API is horribly inconsistent at times, I've added s
 
 * Delete an NZB from the queue. See `instance.delete()` for arguments.
 
-#### `instance.queue.addurl(URL | ARGS)`
+#### `instance.queue.addurl(URL[, ARGS)`
 
 * Add an NZB to the queue by URL. Or an ARGS object.
     
@@ -152,7 +152,7 @@ However, because the SABnzbd API is horribly inconsistent at times, I've added s
     * `URL`
         - url pointing to an NZB file
     * `ARGS` [Sab API Docs](http://wiki.sabnzbd.org/api#toc28)
-        - Object containing at least `name`=URL and any of the following options `pp`=Post Process Level, `script`=Post Process Script, `cat`=Category, `priority`=Priority
+        - Optional object any of the following options `pp`=Post Process Level, `script`=Post Process Script, `cat`=Category, `priority`=Priority
 
 #### `instance.queue.pause([ID])`
 

--- a/lib/sabnzbd-queue.js
+++ b/lib/sabnzbd-queue.js
@@ -38,14 +38,15 @@ SABnzbdQueue.prototype.entries = function() {
 };
 
 // add an NZB url to the queue
-SABnzbdQueue.prototype.addurl = function(urlOrParams) {
-  var args = {};
-  if (typeof urlOrParams === "string") {
-    args.name = urlOrParams;
+SABnzbdQueue.prototype.addurl = function(url, args) {
+  var params = {};
+  if (args) {
+    params = args;
+    params.name = url;
   } else {
-    args = urlOrParams;
+    params.name = url;
   }
-  return this.delegate.cmd('addurl', args);
+  return this.delegate.cmd('addurl', params);
 };
 
 // pause entire queue (with no argument) or a single download (with

--- a/lib/sabnzbd-queue.js
+++ b/lib/sabnzbd-queue.js
@@ -38,8 +38,14 @@ SABnzbdQueue.prototype.entries = function() {
 };
 
 // add an NZB url to the queue
-SABnzbdQueue.prototype.addurl = function(url) {
-  return this.delegate.cmd('addurl', { name : url });
+SABnzbdQueue.prototype.addurl = function(urlOrParams) {
+  var args = {};
+  if (typeof urlOrParams === "string") {
+    args.name = urlOrParams;
+  } else {
+    args = urlOrParams;
+  }
+  return this.delegate.cmd('addurl', args);
 };
 
 // pause entire queue (with no argument) or a single download (with


### PR DESCRIPTION
I needed the ability to set the category for downloads I added to sabnzbd through the addurl call.

This update preserves backwards compatibility, but adds the option of setting all the args which the sabnzbd API supports in the `add by URL` API call.

Please let me know if you need me to change anything for merge.
