### PR TITLE
Use got instead of request

### DIFF
--- a/lib/sabnzbd.js
+++ b/lib/sabnzbd.js
@@ -1,4 +1,4 @@
-var request = require('request');
+var got     = require('got');
 var debug   = require('debug')('sabnzbd');
 var url     = require('url');
 var qs      = require('querystring');
@@ -41,31 +41,10 @@ var SABnzbd = function SABnzbd(url, apiKey) {
 
 // perform command request
 SABnzbd.prototype.cmd = function(command, args) {
-  // build url for request
-  var url = this.url + '?' + qs.stringify({
-    mode   : command,
-    apikey : this.apiKey,
-    output : 'json'
-  });
-
-  // tack on any passed arguments
-  if (args) {
-    url += '&' + qs.stringify(args);
-  }
-
-  debug('Retrieving url `' + url + '`');
-
-  // perform request
-  return new Promise(function(resolve, reject) {
-    request.get(url, function(err, response, body) {
-      if (err) return reject(err);
-      // Parse JSON response.
-      if (response.headers['content-type'].indexOf('application/json') !== -1) {
-        body = JSON.parse(body);
-      }
-      return resolve(body);
-    });
-  });
+  return bluebird.resolve(got(this.url, {
+    json: true,
+    query: Object.assign({ apikey: this.apiKey, mode: command, output: 'json' }, args)
+  }).then(response => response.body));
 };
 
 // get server version

--- a/lib/sabnzbd.js
+++ b/lib/sabnzbd.js
@@ -1,8 +1,8 @@
-var got     = require('got');
-var debug   = require('debug')('sabnzbd');
-var url     = require('url');
-var qs      = require('querystring');
-var Promise = require('bluebird');
+var got      = require('got');
+var debug    = require('debug')('sabnzbd');
+var url      = require('url');
+var qs       = require('querystring');
+var bluebird = require('bluebird');
 
 // helper classes
 var SABnzbdQueue   = require('./sabnzbd-queue');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bluebird": "^3.5.1",
     "dateutil": "^0.1.0",
     "debug": "^3.1.0",
-    "request": "^2.83.0"
+    "got": "^7"
   },
   "bugs": {
     "email": "robert.klep+node-sabnzbd@gmail.com",


### PR DESCRIPTION
* it's going to auto-retry all network errors 2 times which will make this library more stable
* lesser lines of code

bluebird.resolve is necessary only to make the promise returned by got a bluebird-promise 

if `this.version().bind(this).done` can be replaced with `this.version().then`, then we can remove bluebird too.

`package-lock.json` will need to be updated using NPM